### PR TITLE
fix: macOS compilation

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -364,3 +364,6 @@ MigrationBackup/
 
 # Ionide (cross platform F# VS Code tools) working folder
 .ionide/
+
+# MacOs
+.DS_Store

--- a/mac.MD
+++ b/mac.MD
@@ -14,11 +14,21 @@ https://developers.google.com/j2objc/guides/external-build-projects, https://ace
 
 ## Prerequisites
 
-GLFW is required but uncertain which. Linux uses glfw3-dev
+Install command-line tools:
+
+```
+xcode-select --install
+```
+
+Install glfw:
 
 ```
 brew install glfw
-brew install glfw3
-brew install glfw-dev
-brew install glfw3-dev
+```
+
+## Build
+
+```
+cd src
+make
 ```

--- a/src/6510.cpp
+++ b/src/6510.cpp
@@ -2,7 +2,7 @@
 #include "struse/struse.h"
 #include "6510.h"
 #include "Files.h"
-#include <malloc.h>
+#include <stdlib.h>
 
 // for now support 1 CPU
 

--- a/src/Breakpoints.cpp
+++ b/src/Breakpoints.cpp
@@ -1,7 +1,7 @@
 // breakpoints are added in bulk when VICE stops
 // breakpoints can be added by the debugger
 
-#include <malloc.h>
+#include <stdlib.h>
 #include "platform.h"
 #include "Breakpoints.h"
 #include "HashTable.h"

--- a/src/FileDialog.cpp
+++ b/src/FileDialog.cpp
@@ -10,9 +10,9 @@
 #include "views/Views.h"
 #include "struse/struse.h"
 #include "imgui/imgui.h"
-#ifdef __linux__
+#if defined(__linux__) || defined(__APPLE__)
 #include <unistd.h>
-#include <linux/limits.h>
+#include <limits.h>
 #define PATH_MAX_LEN PATH_MAX
 #define sprintf_s sprintf
 #define GetCurrentDirectory(size, buf) getcwd(buf, size)

--- a/src/Files.cpp
+++ b/src/Files.cpp
@@ -1,5 +1,5 @@
 #include <stdio.h>
-#include <malloc.h>
+#include <stdlib.h>
 #include "Files.h"
 
 bool SaveFile(const char *filename, void* data, size_t size)

--- a/src/Files.h
+++ b/src/Files.h
@@ -8,10 +8,12 @@ uint8_t* LoadBinary(const char* name, size_t& size);
 int fopen_s(FILE **f, const char* filename, const char *options);
 #endif
 
-#ifndef _WIN32
-#include <linux/limits.h>
+#if defined(__APPLE__) || defined(__linux__)
+#include <limits.h>
 #define PATH_MAX_LEN PATH_MAX
-#define sprintf_s sprintf
-#else
+#define sprintf_s(buf, ...) snprintf((buf), sizeof(buf), __VA_ARGS__)
+#elif defined(_WIN32)
 #define PATH_MAX_LEN _MAX_PATH
+#else
+#error "Unknown platform"
 #endif

--- a/src/IceBroLite.cpp
+++ b/src/IceBroLite.cpp
@@ -19,7 +19,6 @@
 
 // C RunTime Header Files
 #include <stdlib.h>
-#include <malloc.h>
 #include <memory.h>
 
 #include "imgui.h"

--- a/src/Image.cpp
+++ b/src/Image.cpp
@@ -1,3 +1,4 @@
+#define GL_SILENCE_DEPRECATION
 #include <stdint.h>
 #include "imgui/imgui.h"
 #include "GLFW/glfw3.h"
@@ -236,8 +237,6 @@ struct sTexArea {
 	{ 36 * 2, 48 * 2, 12 * 2, 12 * 2 },
 	{ 48 * 2, 48 * 2, 12 * 2, 16 * 2 },
 };
-
-const int nIcons = sizeof(aIcons) / sizeof(aIcons[0]);
 
 static ImTextureID aIconID = {};
 static int sIconTexWidth = 0;

--- a/src/Makefile
+++ b/src/Makefile
@@ -51,11 +51,11 @@ endif
 ifeq ($(UNAME_S), Darwin) #APPLE
 	ECHO_MESSAGE = "Mac OS X"
 	LIBS += -framework OpenGL -framework Cocoa -framework IOKit -framework CoreVideo
-	LIBS += -L/usr/local/lib -L/opt/local/lib
+	LIBS += -L/opt/homebrew/lib
 	#LIBS += -lglfw3
 	LIBS += -lglfw
 
-	CXXFLAGS += -I/usr/local/include -I/opt/local/include
+	CXXFLAGS += -I/opt/homebrew/include -std=c++11
 	CFLAGS = $(CXXFLAGS)
 endif
 

--- a/src/Mnemonics.cpp
+++ b/src/Mnemonics.cpp
@@ -897,13 +897,11 @@ int Disassemble(CPU6510* cpu, uint16_t addr, char* dest, int left, int& argOffs,
 {
 	strovl str(dest, left);
 	const dismnm* opcodes = a6502_ops;
-	int bytes = 1;
 	unsigned char op = cpu->GetByte(addr);
 	bool not_valid = opcodes[op].mnemonic == mnm_inv || (!illegals && opcodes[op].mnemonic >= mnm_wdc_and_illegal_instructions);
 
 	int arg_size = not_valid ? 0 : opcodes[op].arg_size;;
 	int mode = not_valid ? AM_NON : opcodes[op].addrMode;
-	bytes += arg_size;
 
 	if (showBytes) {
 		for (uint16_t b = 0; b <= (uint16_t)arg_size; b++) {
@@ -992,12 +990,10 @@ int Assemble(CPU6510* cpu, char* cmd, uint16_t addr)
 		return 0;	// instruction not found
 
 	// get valid address modes
-	int addr_modes = 0;
 	int addr_mode_mask = 0;
 	uint8_t op_code_instr[AM_COUNT] = { (uint8_t)0xff };
 	for (int i = 0; i < 256; i++) {
 		if (a6502_ops[i].mnemonic == mnm) {
-			addr_modes++;
 			addr_mode_mask |= 1 << a6502_ops[i].addrMode;
 			op_code_instr[a6502_ops[i].addrMode] = (uint8_t)i;
 		}

--- a/src/Platform.cpp
+++ b/src/Platform.cpp
@@ -1,6 +1,6 @@
 #include "platform.h"
 #include <stdint.h>
-#include <malloc.h>
+#include <stdlib.h>
 #include <stdio.h>
 
 void IBMutexInit(IBMutex* mutex, const char* name)

--- a/src/SourceDebug.cpp
+++ b/src/SourceDebug.cpp
@@ -2,7 +2,7 @@
 #include "../struse/xml.h"
 #include "Sym.h"
 #include "Files.h"
-#include <malloc.h>
+#include <stdlib.h>
 #include <vector>
 #include <assert.h>
 #include "ViceInterface.h"

--- a/src/StartVice.cpp
+++ b/src/StartVice.cpp
@@ -92,7 +92,7 @@ void* LoadViceEXEThread(void* param)
 	return true;// nullptr;
 }
 
-#elif defined(__linux__)
+#elif defined(__linux__) || defined(__APPLE__)
 
 // The standard UNIX way is to use fork(2) followed by an exec(3)
 // call(there's a whole family of them�choose whichever suits

--- a/src/Sym.cpp
+++ b/src/Sym.cpp
@@ -6,7 +6,7 @@
 #include "struse/struse.h"
 #include "6510.h"
 #include <string.h>
-#include <malloc.h>
+#include <stdlib.h>
 #include "HashTable.h"
 #include "Files.h"
 #include "SourceDebug.h"

--- a/src/Traces.cpp
+++ b/src/Traces.cpp
@@ -29,7 +29,7 @@ struct TraceArray {
 };
 
 static const uint32_t cycles_per_frame_pal = 19656;
-static const uint32_t cycles_per_frame_ntsc = 17095;
+[[ maybe_unused ]] static const uint32_t cycles_per_frame_ntsc = 17095;
 
 static bool sTraceStart = false;
 static int sTracePointIdx = 0;

--- a/src/ViceInterface.cpp
+++ b/src/ViceInterface.cpp
@@ -10,7 +10,7 @@
 #endif
 #include <inttypes.h>
 #include <stdio.h>
-#include <malloc.h>
+#include <stdlib.h>
 #include <queue>
 #include <vector>
 #include <assert.h>

--- a/src/ViceMonitorInterface.cpp
+++ b/src/ViceMonitorInterface.cpp
@@ -10,7 +10,7 @@
 #include <netdb.h>
 #endif
 #include <inttypes.h>
-#include <malloc.h>
+#include <stdlib.h>
 #include <assert.h>
 #include "platform.h"
 #include "struse/struse.h"

--- a/src/platform.h
+++ b/src/platform.h
@@ -17,7 +17,7 @@ typedef HANDLE IBMutex;
 typedef HANDLE IBThread;
 typedef IBThreadRet(WINAPI* IBThreadFunc)(void* data);
 
-#elif __linux__
+#elif defined(__linux__) || defined(__APPLE__)
 
 #define IBMutex_Clear 0
 #define IBThread_Clear 0

--- a/src/struse/struse.h
+++ b/src/struse/struse.h
@@ -2794,13 +2794,11 @@ int strref::find_case_esc_range(const strref str, const strref range, strl_t pos
 		if (b == c) {
 			const uint8_t *chk_scan = scan;
 			const uint8_t *chk_compare = compare;
-			strl_t chk_scan_left = scan_left;
 			strl_t chk_compare_left = compare_left;
 			while (chk_compare_left) {
 				uint8_t d = *chk_compare++;
 				chk_compare_left--;
 				uint8_t e = *chk_scan++;
-				chk_scan_left--;
 				if (d=='\\' && compare_left) {
 					strl_t skip = int_get_esc_code(compare, compare_left, d);
 					compare += skip;
@@ -2860,13 +2858,11 @@ int strref::find_esc_range(const strref str, const strref range, strl_t pos) con
 		if (b == c) {
 			const uint8_t *chk_scan = scan;
 			const uint8_t *chk_compare = compare;
-			strl_t chk_scan_left = scan_left;
 			strl_t chk_compare_left = compare_left;
 			while (chk_compare_left) {
 				uint8_t d = int_tolower_ascii7(*chk_compare++);
 				chk_compare_left--;
 				uint8_t e = int_tolower_ascii7(*chk_scan++);
-				chk_scan_left--;
 				if (d=='\\' && compare_left) {
 					strl_t skip = int_get_esc_code(compare, compare_left, d);
 					compare += skip;

--- a/src/views/BreakpointView.cpp
+++ b/src/views/BreakpointView.cpp
@@ -145,8 +145,6 @@ void BreakpointView::Draw()
 		ImGuiTableFlags_BordersOuter | ImGuiTableFlags_BordersV |
 		ImGuiTableFlags_ScrollY;
 
-	ImVec2 outer_size(-FLT_MIN, 0.0f);
-
 	ImVec2 mousePos = ImGui::GetMousePos();
 	ImVec2 winPos = ImGui::GetWindowPos();
 	ImVec2 winSize = ImGui::GetWindowSize();

--- a/src/views/CodeView.cpp
+++ b/src/views/CodeView.cpp
@@ -1,7 +1,7 @@
 #include "CodeView.h"
 #include "../imgui/imgui.h"
 #include "../struse/struse.h"
-#include <malloc.h>
+#include <stdlib.h>
 #include "Views.h"
 #include "../Expressions.h"
 #include "../C64Colors.h"

--- a/src/views/ConsoleView.h
+++ b/src/views/ConsoleView.h
@@ -1,7 +1,7 @@
 #pragma once
 #include "../imgui/imgui.h"
 #include "../struse/struse.h"
-#include <malloc.h>
+#include <stdlib.h>
 struct UserData;
 
 struct IceConsole

--- a/src/views/FilesView.cpp
+++ b/src/views/FilesView.cpp
@@ -1,5 +1,5 @@
 // attempting a home made file dialog in ImGui for a little more portability
-#ifdef __linux__
+#if defined(__linux__) || defined(__APPLE__)
 #include <dirent.h>
 #include <sys/stat.h>
 #elif _WIN32
@@ -10,7 +10,7 @@
 #include "../struse/struse.h"
 #include "FilesView.h"
 #include <string.h>
-#include <malloc.h>
+#include <stdlib.h>
 #include "imgui.h"
 #include "imgui_internal.h"
 
@@ -113,7 +113,7 @@ void FVFileView::Draw(const char *title)
 				if (files[i].fileType == FVFileInfo::dir) {
 					ImGui::Text("(dir)");
 				} else {
-					if (files[i].size < (10 * 1024)) { ImGui::Text("%ld", files[i].size); }
+					if (files[i].size < (10 * 1024)) { ImGui::Text("%llu", files[i].size); }
 					else  if (files[i].size < (1024 * 1024)) { ImGui::Text("%.1fkb", (float)(files[i].size/1024.0f)); }
 					else { ImGui::Text("%.2fMb", (float)(files[i].size / (1024.0f*1024.0f))); }
 				}
@@ -178,7 +178,7 @@ static bool CheckFileFilter(strref name, strref filters)
 	return false;
 }
 
-#ifdef __linux__
+#if defined(__linux__) || defined(__APPLE__)
 
 void FVFileList::ReadDir(const char *full_path, const char*file_filter)
 {

--- a/src/views/FilesView.h
+++ b/src/views/FilesView.h
@@ -1,8 +1,8 @@
 #pragma once
 
 #include <vector>
-#ifdef __linux__
-#include <linux/limits.h>
+#if defined(__linux__) || defined(__APPLE__)
+#include <limits.h>
 #define PATH_MAX_LEN PATH_MAX
 #elif _WIN32
 #define PATH_MAX_LEN _MAX_PATH

--- a/src/views/GfxView.cpp
+++ b/src/views/GfxView.cpp
@@ -1,7 +1,7 @@
 // example for creating a texture:
 // static void ImGui_ImplDX11_CreateFontsTexture()
 #include <stdio.h>
-#include <malloc.h>
+#include <stdlib.h>
 #include <inttypes.h>
 #include "../imgui/imgui.h"
 #include "../imgui/imgui_internal.h"

--- a/src/views/MemView.cpp
+++ b/src/views/MemView.cpp
@@ -1,7 +1,7 @@
 #include "MemView.h"
 #include "../imgui/imgui.h"
 #include "../struse/struse.h"
-#include <malloc.h>
+#include <stdlib.h>
 #include "Views.h"
 #include "../6510.h"
 #include "../Expressions.h"
@@ -108,7 +108,7 @@ void MemView::Draw(int index)
 
 	if (evalAddress||(fixedAddress && cpu->MemoryChange())) {
 		SetAddr(ValueFromExpression(address+(fixedAddress ? 1 : 0)));
-		spanValue = span ? ValueFromExpression(span) : 0;
+		spanValue = ValueFromExpression(span);
 		evalAddress = false;
 	}
 

--- a/src/views/RegView.cpp
+++ b/src/views/RegView.cpp
@@ -1,4 +1,4 @@
-#include <malloc.h>
+#include <stdlib.h>
 #include "../imgui/imgui.h"
 #include "../imgui/imgui_internal.h"
 #include "../struse/struse.h"

--- a/src/views/ScreenView.cpp
+++ b/src/views/ScreenView.cpp
@@ -1,4 +1,4 @@
-#include <malloc.h>
+#include <stdlib.h>
 #include <stdint.h>
 #include "../imgui/imgui.h"
 #include "../imgui/imgui_internal.h"

--- a/src/views/SymbolView.cpp
+++ b/src/views/SymbolView.cpp
@@ -90,7 +90,6 @@ void SymbolView::Draw()
         ImGuiTableFlags_BordersOuter | ImGuiTableFlags_BordersV |
         ImGuiTableFlags_ScrollY;
 
-    ImVec2 outer_size(-FLT_MIN, 0.0f);
     if (ImGui::BeginTable("##symbolstable", 3, flags)) {
         ImGui::TableSetupColumn("Addr", ImGuiTableColumnFlags_DefaultSort | ImGuiTableColumnFlags_WidthStretch, -1.0f, SymbolColumnID_Address);
         ImGui::TableSetupColumn("Symbol", ImGuiTableColumnFlags_WidthStretch, -1.0f, SymbolColumnID_Symbol);


### PR DESCRIPTION
- Suppress GL deprecation warnings
- Emulate safe sprintf_s using snprintf
- Added instructions to compile on macOS
- malloc.h -> stdlib.h
- conditional compilation
- linux/limits.h -> limits.h for macOS compatibility
- Remove dead variables / code